### PR TITLE
ruby 1.8 compatible hash notation and a channel prefix repair fix

### DIFF
--- a/lib/slack-notify/client.rb
+++ b/lib/slack-notify/client.rb
@@ -24,12 +24,12 @@ module SlackNotify
     def notify(text, channel = nil)
       delivery_channels(channel).each do |chan|
         payload = SlackNotify::Payload.new(
-          text:       text,
-          channel:    chan,
-          username:   @username,
-          icon_url:   @icon_url,
-          icon_emoji: @icon_emoji,
-          link_names: @link_names
+          :text  =>    text,
+          :channel =>    chan,
+          :username =>  @username,
+          :icon_url =>   @icon_url,
+          :icon_emoji => @icon_emoji,
+          :link_names => @link_names
         )
 
         send_payload(payload)

--- a/lib/slack-notify/payload.rb
+++ b/lib/slack-notify/payload.rb
@@ -10,7 +10,7 @@ module SlackNotify
       @icon_emoji = options[:icon_emoji]
       @link_names = options[:link_names]
 
-      unless channel[0] =~ /^(#|@)/
+      unless channel.match(/^(#|@)/o)
         @channel = "##{@channel}"
       end
     end

--- a/lib/slack-notify/payload.rb
+++ b/lib/slack-notify/payload.rb
@@ -17,12 +17,12 @@ module SlackNotify
 
     def to_hash
      hash = {
-        text:       text,
-        username:   username,
-        channel:    channel,
-        icon_url:   icon_url,
-        icon_emoji: icon_emoji,
-        link_names: link_names
+        :text => text,
+        :username =>  username,
+        :channel =>   channel,
+        :icon_url =>  icon_url,
+        :icon_emoji => icon_emoji,
+        :link_names => link_names
       }
 
       hash.delete_if { |_,v| v.nil? }


### PR DESCRIPTION
Hi,
I've found a little bug at the channel prefix check code.
And I need to use slack in ruby 1.8.7 project.

Maybe you'll find it useful.

Regards,
Matthias